### PR TITLE
Add chat interface to builder UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ fresh conversation. When generation finishes, the UI opens `site-dir/index.html`
 in your browser and shows the path in a link. You can also press **Open Site**
 at any time to view the latest version.
 
+The interface also includes a chat area that displays the full conversation.
+You can send additional messages in the **Chat input** box and press **Send** to
+continue iterating on the site. The latest assistant replies and your prompts
+appear in the **Conversation** window so you can track changes easily.
+
 ## Using the agent
 
 You can call the `compound_tool` function programmatically to instruct the agent to build a website. Example:


### PR DESCRIPTION
## Summary
- add conversation window and chat input to the GUI
- update README with instructions on the chat interface

## Testing
- `python -m py_compile website_builder_ui.py website_mcp.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_68763a715df4832bbcc7f23368399b1b