### PR TITLE
Fix model dropdown when using .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ echo "GROQ_API_KEY=your_key_here" > .env
 echo "GEMINI_API_KEY=your_gemini_key" >> .env
 ```
 The `GEMINI_API_KEY` is optional and only required if you plan to run the agent
-with Google's Gemini models (model names starting with `gemini`).
+with Google's Gemini models (model names starting with `gemini`). Both
+`website_mcp.py` and the graphical UI automatically load this `.env` file, so
+the keys do not need to be exported globally.
 
 ## Running the server
 

--- a/website_builder_ui.py
+++ b/website_builder_ui.py
@@ -7,12 +7,18 @@ import shutil
 import re
 import anyio
 import webbrowser
+from dotenv import load_dotenv
 from mcp.client.session_group import ClientSessionGroup, SseServerParameters
 
 MCP_PORT = 4876
 MCP_URL = f"http://localhost:{MCP_PORT}/sse"
 UPLOAD_DIR = os.path.join("site-dir", "uploads")
 DOCS_DIR = os.path.join("site-dir", "docs")
+
+# Load environment variables from a .env file if present so the UI and
+# MCP server both have access to API keys without requiring them to be
+# exported globally.
+load_dotenv()
 
 # Lists of available models sorted by release date (latest first). Only Groq
 # and Gemini models are included here.


### PR DESCRIPTION
## Summary
- import `load_dotenv()` in `website_builder_ui.py`
- automatically load `.env` so available models are detected
- clarify in README that the UI loads the `.env` file

## Testing
- `python -m pip install -r requirements.txt`
- `python website_builder_ui.py` *(fails: no $DISPLAY)*

------
https://chatgpt.com/codex/tasks/task_e_6876a27e76f0832bbe5252fdddfbb255