### PR TITLE
Fix nested site-dir paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ html = asyncio.run(compound_tool(messages))
 The generated site will be written inside `site-dir/` using the agent's tools.
 
 All file paths passed to tools like `write_file` or `read_file` must be
-relative to `site-dir/`. Absolute paths are rejected to keep generation
+relative to `site-dir/` (for example `index.html` or `css/main.css`). Do not
+prefix paths with `site-dir/`. Absolute paths are rejected to keep generation
 contained within the sandbox.
 
 You can keep the `messages` list and append more `{"role": "user"}` entries to

--- a/autonomous_builder.py
+++ b/autonomous_builder.py
@@ -8,8 +8,9 @@ from website_mcp import compound_tool
 # ensure the model actually writes HTML/CSS rather than only describing it.
 SYSTEM_PROMPT = (
     "You are an expert web developer. Use write_file to create or overwrite "
-    "files inside the site-dir as you build the site. Replace existing files "
-    "when refining the project."
+    "files when building the site. Provide paths relative to the site-dir "
+    "sandbox such as 'index.html' or 'css/style.css' \u2013 do not prefix them "
+    "with 'site-dir/'. Replace existing files when refining the project."
 )
 
 

--- a/website_builder_ui.py
+++ b/website_builder_ui.py
@@ -20,8 +20,8 @@ DOCS_DIR = os.path.join("site-dir", "docs")
 # files in the sandbox using write_file.
 SYSTEM_PROMPT = (
     "You are an expert web developer. Use write_file to create or replace HTML, "
-    "CSS and JS files inside the site-dir. Overwrite existing files when "
-    "refining the site."
+    "CSS and JS files. Provide paths relative to the site-dir sandbox, for "
+    "example 'index.html' or 'scripts/app.js'. Do not prefix paths with 'site-dir/'. Overwrite existing files when refining the site."
 )
 
 # Load environment variables from a .env file if present so the UI and

--- a/website_mcp.py
+++ b/website_mcp.py
@@ -36,7 +36,9 @@ app = FastMCP()
 
 
 class PathArg(BaseModel):
-    path: str = Field(..., description="Relative path under ./site-dir/")
+    path: str = Field(
+        ..., description="Relative path inside site-dir (e.g. 'index.html')"
+    )
 
 
 @app.tool(name="write_file", description="Create or overwrite a text file")


### PR DESCRIPTION
## Summary
- clarify instruction for relative paths in readme and code
- update system prompts in UI and autonomous builder
- clarify PathArg description in MCP server

## Testing
- `python -m py_compile autonomous_builder.py website_mcp.py website_builder_ui.py`

------
https://chatgpt.com/codex/tasks/task_e_687746519c90832bb466a2ba270f1d39